### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,28 +14,28 @@ The image is currently based on Ubuntu:12.04
 It features Puppet [Chef is optional] and a sample NginX web Server
 
 
-###Simple usage:
-#####Builds your own docker image from the Dockerfile
+### Simple usage:
+##### Builds your own docker image from the Dockerfile
 cd vagrant-docker
 
 sudo **vagrant up**
 
-###Test:
+### Test:
 Navigate to: http://localhost:8080/
 
 
-###Advanced usage:
-#####Select your image in a ENV var
+### Advanced usage:
+##### Select your image in a ENV var
 
-#####For a vanilla image built using the same docker file:
+##### For a vanilla image built using the same docker file:
 
 DOCKER_IMAGE='npoggi/vagrant-docker' sudo vagrant up --provision
 
-#####For a pre-provisioned image with the puppet config (saves time)
+##### For a pre-provisioned image with the puppet config (saves time)
 
 DOCKER_IMAGE='npoggi/vagrant-docker-provisioned' sudo vagrant up --provision
 
-###Notes:
+### Notes:
 In case you switch images do a **vagrant provision** (or vagrant up --provision) instead of just vagrant up.
 As *docker* by default stops services if not specified in the Dockerfile.
 Puppet as the provisioner with make sure they are UP!


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
